### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -18,7 +18,7 @@ require_once DOKU_PLUGIN.'syntax.php';
  * need to inherit from this class
  */
 class action_plugin_filterrss extends DokuWiki_Action_Plugin {
-    function register(&$controller) {
+    function register(Doku_Event_Handler $controller) {
 	$controller->register_hook('PARSER_CACHE_USE', 'BEFORE', $this, '_preventCache', array ());
     }
     /**

--- a/syntax.php
+++ b/syntax.php
@@ -31,7 +31,7 @@ class syntax_plugin_filterrss extends DokuWiki_Syntax_Plugin {
 	$this->Lexer->addSpecialPattern('\[filterrss.*?\]',$mode,'plugin_filterrss');
     }
 
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
 
 	//Remove ] from the end
 	$match = substr($match, 0, -1);
@@ -133,7 +133,7 @@ class syntax_plugin_filterrss extends DokuWiki_Syntax_Plugin {
 	return array('url' => $url, 'conditions' => $cond_output, 'order_by' => $order_by, 'desc' => $desc, 'limit' => $limit);
     }
 
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if($mode == 'xhtml') {
 
 	    $filterrss =& plugin_load('helper', 'filterrss');


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
